### PR TITLE
Updated to Gnuplot.jl v1.6

### DIFF
--- a/examples/contours/contour.jl
+++ b/examples/contours/contour.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 Random.seed!(123)

--- a/examples/contours/contour_egg.jl
+++ b/examples/contours/contour_egg.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 Random.seed!(123)

--- a/examples/filledcu/between.jl
+++ b/examples/filledcu/between.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let

--- a/examples/filledcu/filled.jl
+++ b/examples/filledcu/filled.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let

--- a/examples/filledcu/glow.jl
+++ b/examples/filledcu/glow.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let

--- a/examples/heatmaps/heatmap.jl
+++ b/examples/heatmaps/heatmap.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 Random.seed!(1234)

--- a/examples/heatmaps/heatmap_cblabel.jl
+++ b/examples/heatmaps/heatmap_cblabel.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 Random.seed!(123)

--- a/examples/heatmaps/heatmap_continuous.jl
+++ b/examples/heatmaps/heatmap_continuous.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 let

--- a/examples/heatmaps/heatmap_discrete.jl
+++ b/examples/heatmaps/heatmap_discrete.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 let

--- a/examples/heatmaps/heatmap_multiplot.jl
+++ b/examples/heatmaps/heatmap_multiplot.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 let

--- a/examples/heatmaps/heatmap_volcano.jl
+++ b/examples/heatmaps/heatmap_volcano.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, ColorSchemes, RDatasets
 let

--- a/examples/lines/dates.jl
+++ b/examples/lines/dates.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:tableau_hue_circle, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Dates
 let 

--- a/examples/lines/dates_break2_axis.jl
+++ b/examples/lines/dates_break2_axis.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:tableau_hue_circle, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Dates
 let 

--- a/examples/lines/dates_break3_axis.jl
+++ b/examples/lines/dates_break3_axis.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:tableau_hue_circle, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Dates
 let 

--- a/examples/lines/line.jl
+++ b/examples/lines/line.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 t = 0:0.001:1

--- a/examples/lines/line_cb.jl
+++ b/examples/lines/line_cb.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, ColorSchemes
 x = LinRange(-2π,2π,200)

--- a/examples/lines/line_type.jl
+++ b/examples/lines/line_type.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let 

--- a/examples/lines/line_types.jl
+++ b/examples/lines/line_types.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let 

--- a/examples/lines/two_lines.jl
+++ b/examples/lines/two_lines.jl
@@ -3,7 +3,7 @@ Gnuplot.quitall()#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 x = -2π:0.001:2π

--- a/examples/scatters/scatter.jl
+++ b/examples/scatters/scatter.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 @gp 1:10

--- a/examples/scatters/scatter_line.jl
+++ b/examples/scatters/scatter_line.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 x = -2π:0.001:2π

--- a/examples/scatters/scatter_line_markers.jl
+++ b/examples/scatters/scatter_line_markers.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, ColorSchemes
 @gp key="left" linetypes(:mk_12, dashed=true, ps=0.85)

--- a/examples/surfaces/sombrero.jl
+++ b/examples/surfaces/sombrero.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 Random.seed!(123)

--- a/examples/surfaces/sphere.jl
+++ b/examples/surfaces/sphere.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 Random.seed!(123)

--- a/examples/surfaces/torus.jl
+++ b/examples/surfaces/torus.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 let

--- a/examples/surfaces/torus_depth_sorting.jl
+++ b/examples/surfaces/torus_depth_sorting.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let

--- a/examples/surfaces/tube.jl
+++ b/examples/surfaces/tube.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 let

--- a/examples/wires/sombrero.jl
+++ b/examples/wires/sombrero.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let

--- a/examples/wires/sphere.jl
+++ b/examples/wires/sphere.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot, Random
 Random.seed!(123)

--- a/examples/wires/torus.jl
+++ b/examples/wires/torus.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let

--- a/examples/wires/tube.jl
+++ b/examples/wires/tube.jl
@@ -4,7 +4,7 @@ mkpath("assets")#hide
 Gnuplot.options.term = "unknown"#hide
 empty!(Gnuplot.options.init)#hide
 push!( Gnuplot.options.init, linetypes(:Set1_5, lw=1.5, ps=1.5))#hide
-saveas(file) = save(term="svg size 550,350 fontscale 0.8", output="assets/$(file).svg")#hide
+saveas(file) = Gnuplot.save(term="svg size 550,350 fontscale 0.8", "assets/$(file).svg")#hide
 
 using Gnuplot
 let


### PR DESCRIPTION
Hi!
This is a small PR to adapt to the minor changes in Gnuplot.jl v1.6.
Briefly:
- `save` is no longer exported, hence we need to invoke it as `Gnuplot.save`;
-  the `output=` keyword is no longer optional, it is a mandatory argument to `save`.

